### PR TITLE
Style improvements (colour and no blinking)

### DIFF
--- a/stylesheets/overtype-mode.less
+++ b/stylesheets/overtype-mode.less
@@ -6,3 +6,10 @@
   border: 1px solid @syntax-cursor-color;
   background-color: fade(@syntax-cursor-color, 20%);
 }
+
+// Preventing blinking when editor is not focused
+atom-text-editor.is-focused .cursors.blink-off .cursor {
+  &.overtype-cursor {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
Using cursor colour from a theme and prevented blinking when editor is not focused

Before and after:

![1](https://cloud.githubusercontent.com/assets/7157049/5288948/88b70e4c-7b31-11e4-9448-3df35a65f265.png) ![2](https://cloud.githubusercontent.com/assets/7157049/5288949/88c08486-7b31-11e4-9680-a7f3268bd0a5.png)
